### PR TITLE
refactor(events): extract reusable event loading helpers

### DIFF
--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,67 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { Timeline, Section, Link, Stack, SectionIntro, AnimationProvider, Animate } from '@primer/react-brand'
-
-interface EventData {
-    event_id: string;
-    event_name: string;
-    event_link: string;
-    event_date: string;
-}
+import { useEvents } from '../hooks'
+import type { EventData } from '../types/event'
+import { formatDateEs } from '../utils/date'
 
 const TimelineSection: React.FC = () => {
-    const [events, setEvents] = useState<EventData[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const { data, loading, error } = useEvents();
 
-    useEffect(() => {
-        const loadEvents = async () => {
-            try {
-                // Usar la misma URL tanto en desarrollo como en producción
-                const jsonUrl = `${process.env.PUBLIC_URL}/data/issues.json`;
-
-                console.log('Loading events from:', jsonUrl); // Debug log
-
-                const response = await fetch(jsonUrl);
-
-                if (!response.ok) {
-                    throw new Error(`Error loading events: ${response.status}`);
-                }
-
-                const eventsData: EventData[] = await response.json();
-
-                console.log('Loaded events:', eventsData.length); // Debug log
-
-                // Ordenar eventos por fecha (más recientes primero)
-                const sortedEvents = eventsData.sort((a, b) => {
-                    const dateA = new Date(a.event_date);
-                    const dateB = new Date(b.event_date);
-                    return dateB.getTime() - dateA.getTime();
-                });
-
-                setEvents(sortedEvents);
-            } catch (err) {
-                console.error('Error loading events:', err);
-                setError(err instanceof Error ? err.message : 'Error desconocido');
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        loadEvents();
-    }, []);
-
-    const formatDate = (dateString: string): string => {
-        try {
-            const date = new Date(dateString);
-            return date.toLocaleDateString('es-ES', {
-                day: '2-digit',
-                month: '2-digit',
-                year: 'numeric'
-            });
-        } catch {
-            return dateString; // Fallback al string original si no se puede parsear
-        }
-    };
+    const events = useMemo(() => {
+        return [...data].sort((a: EventData, b: EventData) => {
+            const dateA = new Date(a.event_date);
+            const dateB = new Date(b.event_date);
+            return dateB.getTime() - dateA.getTime();
+        });
+    }, [data]);
 
     if (loading) {
         return (
@@ -127,7 +79,7 @@ const TimelineSection: React.FC = () => {
                         return (
                             <Timeline.Item key={event.event_id}>
                                 <Animate animate="fade-in">
-                                    {formatDate(event.event_date)}{' '}
+                                    {formatDateEs(event.event_date)}{' '}
                                 </Animate>
                                 <Animate animate="slide-in-right">
                                     <Link

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useOrganizers } from './useOrganizers'
+export { useEvents } from './useEvents'

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { fetchEventData } from '../services/events'
+import type { EventData } from '../types/event'
+
+interface UseEventsState {
+  data: EventData[]
+  loading: boolean
+  error: string | null
+}
+
+export const useEvents = (): UseEventsState => {
+  const [state, setState] = useState<UseEventsState>({
+    data: [],
+    loading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    let mounted = true
+
+    const loadEvents = async () => {
+      try {
+        const events = await fetchEventData()
+
+        if (mounted) {
+          setState({ data: events, loading: false, error: null })
+        }
+      } catch (err) {
+        if (mounted) {
+          const errorMessage = err instanceof Error ? err.message : 'Error desconocido'
+          setState({ data: [], loading: false, error: errorMessage })
+        }
+      }
+    }
+
+    loadEvents()
+
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  return state
+}

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -1,0 +1,17 @@
+import type { EventData } from '../types/event'
+import { getBasePath } from '../utils/publicUrl'
+
+export const buildEventDataUrl = (): string => {
+  const basePath = getBasePath()
+  return `${basePath}/data/issues.json`
+}
+
+export const fetchEventData = async (): Promise<EventData[]> => {
+  const response = await fetch(buildEventDataUrl())
+
+  if (!response.ok) {
+    throw new Error(`Error loading events: ${response.status}`)
+  }
+
+  return response.json()
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,2 @@
+export { buildEventDataUrl, fetchEventData } from './events'
 export { buildOrganizerDataUrl, fetchOrganizerData } from './organizers'

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,6 @@
+export interface EventData {
+  event_id: string
+  event_name: string
+  event_link: string
+  event_date: string
+}

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -1,0 +1,11 @@
+import { formatDateEs } from '../date'
+
+describe('formatDateEs', () => {
+  it('formats valid dates for the Spanish locale', () => {
+    expect(formatDateEs('2025-10-05')).toBe('05/10/2025')
+  })
+
+  it('returns the original string for invalid dates', () => {
+    expect(formatDateEs('not-a-date')).toBe('not-a-date')
+  })
+})

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,17 @@
+export const formatDateEs = (dateString: string): string => {
+  try {
+    const date = new Date(dateString)
+
+    if (Number.isNaN(date.getTime())) {
+      return dateString
+    }
+
+    return date.toLocaleDateString('es-ES', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    })
+  } catch {
+    return dateString
+  }
+}


### PR DESCRIPTION
## Summary

- extract event fetching into a dedicated service and hook
- add a shared Spanish date formatter for event rendering
- refactor the current timeline to use the new helpers without changing the UI flow

## Validation

- `CI=true npm test -- --watchAll=false`
- `npm run build`

## Why now

This is the smallest useful piece that can be rescued from the old event refactor work. It improves reuse and reduces duplicate event-loading logic while keeping the current timeline behavior intact.
